### PR TITLE
Add info about trello board

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 + To participate, head over to [the issue tracker](https://github.com/bundler/bundler-features/issues) and create an issue with your idea for a new feature.
 
++ You can keep track of the Bundler team's discussion of these ideas on the official [trello board](https://trello.com/c/K4zdOFl8/51-default-installs-to-path-bundle-gems)
+
 + For bugs, please use [the regular Bundler issues tracker](https://github.com/bundler/bundler/issues).
 
 + Feel free to fork this repository and send feature pull requests that include code snippets or examples that illustrate your feature request or discussion point.


### PR DESCRIPTION
The [trello board](https://trello.com/c/K4zdOFl8/51-default-installs-to-path-bundle-gems) seems to be the place where the reasoning behind some of the proposed features in the issues is given.